### PR TITLE
Be explicit when warnings are okay

### DIFF
--- a/10/README.md
+++ b/10/README.md
@@ -36,6 +36,6 @@ For that, we will go back to the `main.rs` file, and create our first `#[test]` 
 	}
 	```
 
-4. We can run our tests using `cargo test`, where hopefully you should see that it passes.
+4. We can run our tests using `cargo test`, where hopefully you should see that it passes. **There should be no compiler warnings now!**
 
 I hope at this point you can start to see the beginnings of your simple blockchain state machine.

--- a/12/README.md
+++ b/12/README.md
@@ -69,4 +69,4 @@ In this case, we are writing code which completely handles the `Option` type in 
 
 Follow the instructions in the template to create a safe and simple transfer function in your Balances Pallet.
 
-Create a test showing that everything is working as expected, including error handling.
+Create a test showing that everything is working as expected, including error handling. There should be no compiler warnings!

--- a/15/README.md
+++ b/15/README.md
@@ -21,3 +21,5 @@ We will see the importance of the System Pallet evolve as you walk through the s
 3. Import the `system` module into your `main.rs` file.
 
 You will notice that the instructions here are quite brief. You have already done all of these steps before, so you should already be familiar with everything you need to complete this step.
+
+Confirm everything is compiling. You should expect some "never used/constructed" warnings. That is okay.

--- a/17/README.md
+++ b/17/README.md
@@ -51,4 +51,4 @@ Follow the instructions in the template to complete:
 2. `fn inc_block_number`
 3. `fn inc_nonce`
 
-Then write tests which verify that these functions work as expected, and that your state is correctly updated.
+Then write tests which verify that these functions work as expected, and that your state is correctly updated. There should be no compiler warnings after this step!

--- a/19/README.md
+++ b/19/README.md
@@ -19,3 +19,5 @@ Certainly this sounds pretty abstract, but it will make more sense as we complet
 Just like our Pallets, our Runtime will be represented with a simple `struct`, however in this case, the fields of our `struct` will be our Pallets!
 
 Complete the instructions for creating a new runtime which includes our System and Balances pallets. For this, you will need to take advantage of the `new()` functions we exposed for each of the Pallets.
+
+Make sure your code is formatted and everything is still compiling. Compiler warnings about "never read/used" are okay.

--- a/21/README.md
+++ b/21/README.md
@@ -61,3 +61,5 @@ On real blockchain systems, users are still charged a transaction fee, even when
 Do you think you understand everything it takes to simulate your first block?
 
 Follow the instructions provided by the template to turn your `main` function from "Hello, World!" to actually executing your blockchain's runtime.
+
+At the end of this step, everything should compile and run without warnings!

--- a/23/README.md
+++ b/23/README.md
@@ -54,3 +54,5 @@ To do this, we need to add `#[derive(Debug)]` to the `struct Runtime`.
 However... `struct Runtime` is composed of `system::Pallet` and `balances::Pallet`, so these structs ALSO need to implement the Debug trait.
 
 Complete the `TODO`s across the different files in your project and print out your final runtime at the end of the `main` function.
+
+You can use `cargo run` to see the output of your `println`. Everything should compile and run without warnings.

--- a/40/README.md
+++ b/40/README.md
@@ -61,3 +61,5 @@ Now that you understand what is in the support module, add it to your project.
 2. Copy and paste the content provided into your file.
 3. Import the support module at the top of your `main.rs` file.
 4. Finally, replace your `Result<(), &'static str>` with `crate::support::DispatchResult` in the `fn transfer` function in your Balances Pallet.
+
+Introducing this new module will cause your compiler to emit lots of "never constructed" warnings. Everything should still compile, so that is okay. We will use these new types soon.

--- a/42/README.md
+++ b/42/README.md
@@ -21,3 +21,5 @@ It's time to define the concrete `Block` type that we will use to enhance our si
 As you can see, the `Block` is composed of layers of generic types, allowing the whole structure to be flexible and customizable to our needs.
 
 Pay attention to the generic type definitions to ensure that you use all the correct generic parameters in all the right places.
+
+Your code should still compile with some "never constructed/used" warnings.

--- a/44/README.md
+++ b/44/README.md
@@ -66,3 +66,5 @@ To get the extrinsic number `i`, use you chain the [`enumerate()`](https://doc.r
 You should now have all the tools and information needed to successfully write your `execute_block` function.
 
 Follow the `TODO`s provided by the template, and make sure to include the `impl crate::support::Dispatch for Runtime` that we provided for you, and that we will implement in the next steps.
+
+Your code should still compile with some "never constructed/used" warnings.

--- a/46/README.md
+++ b/46/README.md
@@ -51,3 +51,5 @@ Note that we propagate up any errors returned by our function call with the `?` 
 ## Write Your Dispatch Logic
 
 Follow the `TODO`s provided in the template to build your `RuntimeCall` and complete your `dispatch` logic.
+
+Your code should still compile with some "never constructed/used" warnings. Just one more step and we will get rid of all those warnings!

--- a/48/README.md
+++ b/48/README.md
@@ -43,3 +43,5 @@ This panic will NOT be triggered if there is an error in an extrinsic, as we "sw
 Go ahead and use the `Block` type and `execute_block` function to update the logic of your `main` function.
 
 Follow the `TODO`s provided in the template to complete this step
+
+By the end of this step, your code should compile, test, and run successfully, all without compiler warnings!

--- a/50/README.md
+++ b/50/README.md
@@ -26,4 +26,6 @@ Just like before, you simply need to match the `Call` variant with the appropria
 
 Follow the `TODO`s in the template to complete the logic for Pallet level dispatch.
 
+The "never constructed" warning for the `Transfer` variant is okay.
+
 In the next step, we will use this logic to improve our dispatch logic in our Runtime.

--- a/52/README.md
+++ b/52/README.md
@@ -48,4 +48,4 @@ Since we have updated the construction of the `RuntimeCall` enum, we will also n
 
 Now is the time to complete this step and glue together Pallet level dispatch with the Runtime level dispatch logic.
 
-Follow the `TODO`s provided in the template to get your full end to end dispatch logic running.
+Follow the `TODO`s provided in the template to get your full end to end dispatch logic running. By the end of this step there should be no compiler warnings.

--- a/55/README.md
+++ b/55/README.md
@@ -48,3 +48,5 @@ Let's start to create this pallet:
 4. In your `main.rs` file, import the `proof_of_existence` module.
 
 Make sure that everything compiles after you complete these steps.
+
+Compiler warnings about "never read/used" are okay.

--- a/59/README.md
+++ b/59/README.md
@@ -12,3 +12,5 @@ There is nothing new here, but we have left more for you to fill out than before
 2. Implement the `Dispatch` trait for your `Pallet`.
 
 If you get stuck, try not to look at the solution provided here, but instead look at what you did in the Balances Pallet. Everything we have done here, we have already done in the past. This is an opportunity to catch where you may have outstanding questions or misunderstandings.
+
+Don't worry about compiler warnings like "never used/constructed".

--- a/6/README.md
+++ b/6/README.md
@@ -41,7 +41,7 @@ Maps are simple `key -> value` objects, allowing us to define an arbitrary sized
 	}
 	```
 
-You can confirm at this point that everything should still be compiling, and that you haven't made any small errors.
+You can confirm at this point that everything should still be compiling, and that you haven't made any small errors. Warnings are okay.
 
 Next we will actually start to **use** this module.
 

--- a/61/README.md
+++ b/61/README.md
@@ -20,3 +20,5 @@ Let's take a look at that process.
 Hopefully from this process, you can see how all of the abstractions we have introduced has made integrating new Pallets into your runtime quite easy.
 
 We will make this process even easier in the near future using macros!
+
+By the end of this step, everything should compile without warnings.

--- a/8/README.md
+++ b/8/README.md
@@ -105,4 +105,6 @@ To make our module useful, we need to at least have some functions which will al
 
 	Note that we do our little trick here! Rather than exposing an API which forces the user downstream to handle an `Option`, we instead are able to have our API always return a `u128` by converting any user with `None` value into `0`.
 
+As always, confirm everything is still compiling. Warnings are okay.
+
 Next we will write our first test and actually interact with our balances module.


### PR DESCRIPTION
closes #2 

This is the last of the issues called out in #2 

Now sections will call out at the end when compiler warnings are okay at the end of the step, and when they should totally go away.