### PR TITLE
docs: improve formatting of a block of code sample in step 7's template

### DIFF
--- a/src/7/template/README.md
+++ b/src/7/template/README.md
@@ -14,13 +14,13 @@ For that, we will go back to the `main.rs` file, and create our first `#[test]` 
 2. To begin our test, we need to initialize a new instance of our `Pallet`:
 
 	```rust
-  #[cfg(test)]
-  mod tests {
-  	#[test]
-  	fn init_balances() {
-  		let mut balances = super::Pallet::new();
-  	}
-  }
+	#[cfg(test)]
+	mod tests {
+		#[test]
+		fn init_balances() {
+			let mut balances = super::Pallet::new();
+		}
+	}
 	```
 
 	Note that we make this variable `mut` since we plan to mutate our state using our newly created API.


### PR DESCRIPTION
This fixes the formatting issue shown in the screenshot below:
<img width="1440" height="900" alt="Screenshot 2026-06-12 at 07 30 54" src="https://github.com/user-attachments/assets/4cb91c48-cfd6-4ff7-ad98-f0c000193ba8" />
