### PR TITLE
docs: fix Monaco editor clipping long sentences when mobile is vertical

### DIFF
--- a/src/_gitorial/monaco-setup.css
+++ b/src/_gitorial/monaco-setup.css
@@ -265,7 +265,7 @@ body.gitorial-has-editor .content {
   .gitorial-step-text,
   .gitorial-step-editor {
     height: auto;
-    overflow: visible;
+    overflow: hidden;
   }
 
   .gitorial-monaco {


### PR DESCRIPTION
This fixes Monaco editor clipping of long sentences on mobile phones when they're vertically oriented, as shown in the video below:

https://github.com/user-attachments/assets/caf0fb77-f060-4c40-b326-3abeba1aeb76

